### PR TITLE
Attempted fix for #3

### DIFF
--- a/Source/Prepatcher.cs
+++ b/Source/Prepatcher.cs
@@ -251,12 +251,19 @@ namespace Prepatcher
             if (fieldTypeType != null)
             {
                 var str = xml.Attributes[DefaultValueAttr]?.Value;
-                if (str == "new()" && fieldTypeType.GetConstructor(new Type[0]) != null)
-                    defaultValue = NewFieldData.DEFAULT_VALUE_NEW_CTOR;
-                else if (GetConstantOpCode(fieldTypeType) != null)
-                    defaultValue = ParseHelper.FromString(str, fieldTypeType);
-                else if (fieldTypeType.IsValueType)
-                    defaultValue = Activator.CreateInstance(fieldTypeType);
+                if(str != null)
+                {
+                    if (str == "new()" && fieldTypeType.GetConstructor(new Type[0]) != null)
+                        defaultValue = NewFieldData.DEFAULT_VALUE_NEW_CTOR;
+                    else if (GetConstantOpCode(fieldTypeType) != null)
+                    { 
+                        defaultValue = ParseHelper.FromString(str, fieldTypeType);
+                        if(typeof(bool) == fieldTypeType)
+                            defaultValue = str == "false" ? 0 : 1;
+                    }
+                    else if (fieldTypeType.IsValueType)
+                        defaultValue = Activator.CreateInstance(fieldTypeType);
+                }
             }
 
             return new NewFieldData()


### PR DESCRIPTION
- Fixes null error when not passing a default value (ParseHelper.FromString throws an error)
- Also band-aid patches the fact that Cecil seemingly cannot implicitly cast an object with the value `false` or `true` to an integer as the operand of an Ldc_I4 instruction (which is required for the initialisation of the field)

Test case which failed previously for this:

```
<?xml version="1.0" encoding="utf-8"?>
<Fields>
    <Field Name="isNotHackable" FieldType="bool" TargetType="Verse.Pawn" DefaultValue="false"/>
    <Field Name="isHacked" FieldType="bool" TargetType="Verse.Pawn" DefaultValue="true"/>
</Fields>
```