### PR TITLE
1.6 update

### DIFF
--- a/Source/Implementation/Implementation.csproj
+++ b/Source/Implementation/Implementation.csproj
@@ -19,9 +19,9 @@
   <ItemGroup>
 
     <!-- Nuget dependencies -->
-    <PackageReference Include="Krafs.Publicizer" Version="2.2.1" />
-    <PackageReference Include="Lib.Harmony" Version="2.3.3" />
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4069" />
+    <PackageReference Include="Krafs.Publicizer" Version="2.*" />
+    <PackageReference Include="Lib.Harmony" Version="2.3.*" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.*" />
 
   </ItemGroup>
 

--- a/Source/Implementation/UnsafeAssembly.cs
+++ b/Source/Implementation/UnsafeAssembly.cs
@@ -8,7 +8,7 @@ namespace Prepatcher;
 
 internal class UnsafeAssembly
 {
-    private static readonly FieldInfo? MonoAssemblyField = AccessTools.Field(typeof(Assembly), "_mono_assembly");
+    private static readonly FieldInfo? MonoAssemblyField = AccessTools.Field(AccessTools.TypeByName("System.Reflection.RuntimeAssembly"), "_mono_assembly");
 
     private static List<Assembly> refOnly = new();
 

--- a/Source/Prepatcher.csproj
+++ b/Source/Prepatcher.csproj
@@ -14,9 +14,9 @@
   <ItemGroup>
 
     <!-- Nuget dependencies -->
-    <PackageReference Include="Krafs.Publicizer" Version="2.1.0" />
-    <PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.4.3580" />
+    <PackageReference Include="Krafs.Publicizer" Version="2.*" />
+    <PackageReference Include="Lib.Harmony" Version="2.*" ExcludeAssets="runtime" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.*" />
 
   </ItemGroup>
 

--- a/Source/Prestarter/Prestarter.csproj
+++ b/Source/Prestarter/Prestarter.csproj
@@ -13,12 +13,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Krafs.Publicizer" Version="2.2.1">
+      <PackageReference Include="Krafs.Publicizer" Version="2.*">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime" />
-      <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4069" />
+      <PackageReference Include="Lib.Harmony" Version="2.3.*" ExcludeAssets="runtime" />
+      <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.*" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/TestAssembly/TestAssembly.csproj
+++ b/Source/TestAssembly/TestAssembly.csproj
@@ -14,13 +14,13 @@
     </ItemGroup>
 
     <ItemGroup>
-  
+
       <!-- Nuget dependencies -->
-      <PackageReference Include="Krafs.Publicizer" Version="2.2.1" />
-      <PackageReference Include="Lib.Harmony" Version="2.2.2" ExcludeAssets="runtime" />
-  
+      <PackageReference Include="Krafs.Publicizer" Version="2.*" />
+      <PackageReference Include="Lib.Harmony" Version="2.3.*" ExcludeAssets="runtime" />
+
     </ItemGroup>
-  
+
     <ItemGroup>
       <Publicize Include="0Harmony" />
     </ItemGroup>

--- a/Source/Tests/Tests.csproj
+++ b/Source/Tests/Tests.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Krafs.Publicizer" Version="2.2.1">
+        <PackageReference Include="Krafs.Publicizer" Version="2.*">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -19,7 +19,7 @@
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.0" />
         <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
         <PackageReference Include="coverlet.collector" Version="3.1.2" />
-        <PackageReference Include="Lib.Harmony" Version="2.3.3" />
+        <PackageReference Include="Lib.Harmony" Version="2.3.*" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
_mono_assembly was moved from System.Reflection.Assembly to System.Reflection.RuntimeAssembly in mono.
Change the type name fixes fatal error during 1.6 startup.
Commit here: https://github.com/Unity-Technologies/mono/commit/e14ef8a658c70bf664eb032b0ccb47a6aab4b281#diff-4b6f98b8749e45ca2b4ac71c214bdcf41918c832be851cbb18d244b1d62153fe


Also updated all references to latest