### PR TITLE
Debug symbols support

### DIFF
--- a/Source/Implementation/Implementation.csproj
+++ b/Source/Implementation/Implementation.csproj
@@ -10,11 +10,9 @@
         <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
         <RootNamespace>Prepatcher</RootNamespace>
         <AssemblyName>PrepatcherImpl</AssemblyName>
+        <DebugType>embedded</DebugType>
     </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-      <DebugType>none</DebugType>
-    </PropertyGroup>
 
   <ItemGroup>
 

--- a/Source/Implementation/Loader.cs
+++ b/Source/Implementation/Loader.cs
@@ -103,7 +103,16 @@ internal static class Loader
     {
         Lg.Verbose($"Loading assembly: {asm}");
 
-        var loadedAssembly = Assembly.Load(asm.Bytes);
+        Assembly loadedAssembly;
+        if (asm.SymbolsLoaded)
+        {
+            Lg.Verbose($"Loading assembly with symbols: {asm}: ");
+            loadedAssembly = Assembly.Load(asm.Bytes, asm.SymbolBytes);
+        }
+        else
+        {
+            loadedAssembly = Assembly.Load(asm.Bytes);
+        }
         if (loadedAssembly.GetName().Name == AssemblyCollector.AssemblyCSharp)
         {
             newAsm = loadedAssembly;

--- a/Source/Implementation/Patches/AssemblyLoadingFreePatch.cs
+++ b/Source/Implementation/Patches/AssemblyLoadingFreePatch.cs
@@ -30,16 +30,6 @@ public static class AssemblyLoadingFreePatch
         if (asmWithName != null)
             return asmWithName;
 
-        var rawAssembly = File.ReadAllBytes(filePath);
-        var fileInfo = new FileInfo(Path.Combine(Path.GetDirectoryName(filePath)!, Path.GetFileNameWithoutExtension(filePath)) + ".pdb");
-        if (fileInfo.Exists)
-        {
-            var rawSymbolStore = File.ReadAllBytes(fileInfo.FullName);
-            return AppDomain.CurrentDomain.Load(rawAssembly, rawSymbolStore);
-        }
-        else
-        {
-            return AppDomain.CurrentDomain.Load(rawAssembly);
-        }
+        return Assembly.LoadFrom(filePath);
     }
 }


### PR DESCRIPTION
AssemblyLoadingFreePatch.cs - ~~on non prepatched return LoadFrom assembly - it already supports all debug symbols~~ if assembly isn't loaded at all then loadFrom feels more normal there as fallback
Enabled embedded symbols on implementation - there isnt really any reason not to include them
Symbol loading for AssemblyDefinition.ReadAssembly is doen with try catch as i dont think there is any actual way to check for presence of embedded symbols